### PR TITLE
feat: implement caching for cacheable jobs in pipeline execution

### DIFF
--- a/.cursor/rules/neuroline-core.mdc
+++ b/.cursor/rules/neuroline-core.mdc
@@ -98,7 +98,8 @@ Job с `cacheable: true` кеширует артефакт через `PipelineS
 { job: expensiveJob, synapses, cacheable: true }
 ```
 
-Кеш встроен в `PipelineStorage` — приложению не нужно ничего дополнительно настраивать.
+Кеш **глобальный** по `jobName` — разделяется между всеми pipeline, использующими эту job (имя job = реализация). При изменении реализации job необходимо очистить кеш вручную.
+Встроен в `PipelineStorage` — приложению не нужно ничего дополнительно настраивать.
 
 ### PipelineStorage
 
@@ -189,8 +190,10 @@ const polling = await client.restartAndPoll(
 ## Кеширование
 
 - `inputHash` = hash(jobName + input + options) — дедупликация артефактов
+- Cache **глобальный**: ключ — `{ jobName, inputHash }`, без привязки к `pipelineType`. Одна и та же job переиспользует кеш во всех pipeline — имя job = реализация
 - Cache встроен в `PipelineStorage` (`findCachedArtifact`/`saveCachedArtifact`), живёт независимо от pipeline
 - Приложению не нужно ничего дополнительно настраивать — достаточно `cacheable: true` в конфиге job
+- **Инвалидация кеша при смене реализации**: если код `execute` изменился, необходимо либо очистить кеш (коллекцию `job_caches` / `jobCache` Map), либо перезапустить все pipeline с этой job
 
 ## Идемпотентность
 

--- a/.cursor/rules/neuroline-core.mdc
+++ b/.cursor/rules/neuroline-core.mdc
@@ -90,11 +90,23 @@ Job может быть настроена на автоматический ret
 
 - `retryCount` и `maxRetries` сохраняются в `JobState` для мониторинга
 
+### Cacheable Jobs
+
+Job с `cacheable: true` кеширует артефакт через `PipelineStorage`. При совпадении `inputHash` (хеш jobName + input + options) результат берётся из кеша без повторного выполнения.
+
+```typescript
+{ job: expensiveJob, synapses, cacheable: true }
+```
+
+Кеш встроен в `PipelineStorage` — приложению не нужно ничего дополнительно настраивать.
+
 ### PipelineStorage
 
-Интерфейс для хранилища. Реализации:
-- `InMemoryPipelineStorage` — для тестов
-- `MongoPipelineStorage` — для продакшена
+Интерфейс для хранилища. Jobs хранятся embedded в документе pipeline.
+Кеш артефактов для cacheable jobs встроен (`findCachedArtifact`/`saveCachedArtifact`), хранится отдельно от pipeline — удаление pipeline **не** удаляет кеш.
+Реализации:
+- `InMemoryPipelineStorage` — для тестов (кеш в Map)
+- `MongoPipelineStorage` — для продакшена (кеш в отдельной коллекции `job_caches`)
 
 ### Manual Jobs
 
@@ -173,6 +185,12 @@ const polling = await client.restartAndPoll(
 3. **Типизация обязательна** — `JobDefinition<TInput, TOutput, TOptions>`
 4. **Имена jobs уникальны** в рамках pipeline
 5. **synapses** — единственный способ получить данные из других jobs
+
+## Кеширование
+
+- `inputHash` = hash(jobName + input + options) — дедупликация артефактов
+- Cache встроен в `PipelineStorage` (`findCachedArtifact`/`saveCachedArtifact`), живёт независимо от pipeline
+- Приложению не нужно ничего дополнительно настраивать — достаточно `cacheable: true` в конфиге job
 
 ## Идемпотентность
 

--- a/packages/demo-pipelines/src/demo-pipeline.ts
+++ b/packages/demo-pipelines/src/demo-pipeline.ts
@@ -6,6 +6,7 @@ import { transformJob, type TransformJobArtifact } from './jobs/transform-job';
 import { failingJob } from './jobs/failing-job';
 import { unstableJob } from './jobs/unstable-job';
 import { finalizeJob } from './jobs/finalize-job';
+import { prepareConfigJob } from './jobs/prepare-config-job';
 
 // ============================================================================
 // Pipeline Input Types
@@ -31,6 +32,14 @@ export interface DemoPipelineInput {
 // ============================================================================
 // Synapses (трансформация данных между jobs)
 // ============================================================================
+
+/**
+ * Synapse: PipelineInput -> PrepareConfig
+ * Передаёт только iterations — стабильный параметр для кеширования
+ */
+const inputToPrepareConfig = (ctx: SynapseContext<DemoPipelineInput>) => ({
+	iterations: ctx.pipelineInput.iterations ?? 10,
+});
 
 /**
  * Synapse: PipelineInput -> Init
@@ -130,26 +139,32 @@ const toFinalize = (ctx: SynapseContext<DemoPipelineInput>) => {
  * Demo Pipeline — демонстрация работы neuroline
  *
  * Структура stages:
- * 1. [init] - инициализация (1 сек)
+ * 1. [init, prepare-config (cacheable)] - параллельно инициализация и подготовка конфигурации
  * 2. [validate, compute] - параллельно валидация и вычисления (1 сек)
  * 3. [transform] - трансформация данных (1.2 сек)
  * 4. [unstable-task, failing-task] - параллельно: нестабильная (с retry) и условно падающая
  * 5. [finalize] - финализация и сборка результата (1 сек)
  *
+ * prepare-config отмечена как cacheable — при повторном запуске с тем же iterations
+ * результат берётся из кеша мгновенно (без 2-секундной задержки).
+ *
  * Если input.fail === true, pipeline упадёт на stage 4
  * unstable-task имеет 2 ретрая — если unstableFailCount <= 2, задача завершится успешно
- * Общее время: ~5-6 секунд (при успехе)
+ * Общее время: ~5-6 секунд (при успехе, ~3-4 при cache hit на prepare-config)
  */
 export const demoPipeline: PipelineConfig<DemoPipelineInput> = {
 	name: 'demo-pipeline',
 	stages: [
-		// Stage 1: Инициализация
-		{ job: initJob, synapses: inputToInit },
+		// Stage 1: Параллельно инициализация и подготовка конфигурации (cacheable)
+		[
+			{ job: initJob, synapses: inputToInit },
+			{ job: prepareConfigJob, synapses: inputToPrepareConfig, cacheable: true },
+		],
 
 		// Stage 2: Параллельно валидация и вычисления
 		[
 			{ job: validateJob, synapses: initToValidate },
-			{ job: computeJob, synapses: inputToCompute },
+			{ job: computeJob, synapses: inputToCompute, cacheable: true },
 		],
 
 		// Stage 3: Трансформация данных

--- a/packages/demo-pipelines/src/index.ts
+++ b/packages/demo-pipelines/src/index.ts
@@ -38,6 +38,10 @@ export {
 	type FinalizeJobInput,
 	type FinalizeJobArtifact,
 	type FinalizeJobOptions,
+	prepareConfigJob,
+	type PrepareConfigJobInput,
+	type PrepareConfigJobArtifact,
+	type PrepareConfigJobOptions,
 } from './jobs';
 
 // ============================================================================

--- a/packages/demo-pipelines/src/jobs/index.ts
+++ b/packages/demo-pipelines/src/jobs/index.ts
@@ -10,3 +10,4 @@ export { transformJob, type TransformJobInput, type TransformJobArtifact, type T
 export { failingJob, type FailingJobInput, type FailingJobArtifact, type FailingJobOptions } from './failing-job';
 export { unstableJob, type UnstableJobInput, type UnstableJobArtifact, type UnstableJobOptions } from './unstable-job';
 export { finalizeJob, type FinalizeJobInput, type FinalizeJobArtifact, type FinalizeJobOptions } from './finalize-job';
+export { prepareConfigJob, type PrepareConfigJobInput, type PrepareConfigJobArtifact, type PrepareConfigJobOptions } from './prepare-config-job';

--- a/packages/demo-pipelines/src/jobs/prepare-config-job.ts
+++ b/packages/demo-pipelines/src/jobs/prepare-config-job.ts
@@ -1,0 +1,66 @@
+import type { JobDefinition } from 'neuroline';
+import { delay } from '../utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Входные данные для prepare-config job */
+export interface PrepareConfigJobInput {
+	iterations: number;
+}
+
+/** Артефакт (результат) prepare-config job */
+export interface PrepareConfigJobArtifact {
+	chunkSize: number;
+	strategy: 'parallel' | 'sequential';
+	thresholds: number[];
+}
+
+/** Опции для prepare-config job */
+export interface PrepareConfigJobOptions {
+	/** Задержка подготовки в мс (по умолчанию 2000) */
+	delayMs?: number;
+}
+
+// ============================================================================
+// Job Definition
+// ============================================================================
+
+/**
+ * Prepare Config Job — подготовка конфигурации вычислений
+ *
+ * Симулирует тяжёлую операцию (загрузка модели, расчёт параметров).
+ * Результат зависит только от iterations — идеальный кандидат для cacheable.
+ * При повторном запуске с тем же iterations результат берётся из кеша мгновенно.
+ */
+export const prepareConfigJob: JobDefinition<PrepareConfigJobInput, PrepareConfigJobArtifact, PrepareConfigJobOptions> = {
+	name: 'prepare-config',
+	async execute(input, options, ctx) {
+		const delayMs = options?.delayMs ?? 2000;
+
+		ctx.logger.info('Подготовка конфигурации вычислений', {
+			iterations: input.iterations,
+			delayMs,
+		});
+
+		// Симулируем тяжёлую операцию (загрузка модели / расчёт параметров)
+		await delay(delayMs);
+
+		const chunkSize = Math.ceil(input.iterations / 3);
+		const strategy = input.iterations > 5 ? 'parallel' : 'sequential';
+
+		const thresholds: number[] = [];
+		for (let i = 1; i <= input.iterations; i++) {
+			thresholds.push(Math.round(Math.pow(i, 1.5) * 100) / 100);
+		}
+
+		ctx.logger.info('Конфигурация подготовлена', { chunkSize, strategy });
+
+		return {
+			chunkSize,
+			strategy,
+			thresholds,
+		};
+	},
+};

--- a/packages/neuroline/README.md
+++ b/packages/neuroline/README.md
@@ -12,6 +12,7 @@ Framework-agnostic pipeline orchestration library with support for:
 - Sequential and parallel job execution
 - Persistent state storage (MongoDB, in-memory, or custom)
 - Type-safe jobs with synapses for data transformation
+- Cacheable jobs (skip re-execution on identical input)
 - Idempotency (re-running with same input data returns existing pipeline)
 
 ## Changelog
@@ -479,6 +480,32 @@ await client.runManualJob(pipelineId, 'approval');
 const polling = await client.runManualJobAndPoll(pipelineId, 'approval', onUpdate, onError);
 ```
 
+## Cacheable Jobs
+
+Jobs can be marked as `cacheable` to skip re-execution when the same input has been processed before. The cache key is `{ jobName, inputHash }`, where `inputHash = SHA-256(jobName + input + options)`.
+
+```typescript
+const config: PipelineConfig = {
+  name: 'my-pipeline',
+  stages: [
+    // Cacheable job — result is stored in cache after first execution
+    { job: expensiveJob, synapses: toExpensive, cacheable: true },
+    // Regular job — always executes
+    normalJob,
+  ],
+};
+```
+
+- `cacheable: true` in `JobInPipeline` — enables caching for the job
+- Cache is **global by `jobName`** — shared across all pipelines that use the same job (job name = implementation)
+- Cache is independent of pipeline lifecycle — deleting a pipeline does **not** clear the cache
+- `restartPipelineFromJob` bypasses the cache for the restarted job and updates it with the new result
+- Storage implementations:
+  - `InMemoryPipelineStorage` — cache stored in a `Map`
+  - `MongoPipelineStorage` — cache stored in a separate `job_caches` collection
+
+**Cache invalidation:** if the `execute` implementation changes, the cache must be cleared manually (drop the `job_caches` collection or call `storage.clear()` for in-memory).
+
 ## Stale Jobs Watchdog
 
 When a process crashes during job execution, the job may remain in `processing` status forever ("stale job"). The watchdog monitors and automatically times out such jobs.
@@ -772,6 +799,7 @@ UNLICENSED
 - Последовательного и параллельного выполнения jobs
 - Персистентного хранения состояния (MongoDB, in-memory, или кастомное)
 - Типобезопасных jobs с synapses для трансформации данных
+- Кеширования jobs (пропуск повторного выполнения при идентичных входных данных)
 - Идемпотентности (повторный запуск с теми же входными данными возвращает существующий pipeline)
 
 ## Changelog
@@ -1238,6 +1266,32 @@ await client.runManualJob(pipelineId, 'approval');
 // Или с polling в одном вызове
 const polling = await client.runManualJobAndPoll(pipelineId, 'approval', onUpdate, onError);
 ```
+
+## Cacheable Jobs
+
+Jobs можно пометить как `cacheable`, чтобы пропускать повторное выполнение при тех же входных данных. Ключ кеша — `{ jobName, inputHash }`, где `inputHash = SHA-256(jobName + input + options)`.
+
+```typescript
+const config: PipelineConfig = {
+  name: 'my-pipeline',
+  stages: [
+    // Cacheable job — результат сохраняется в кеш после первого выполнения
+    { job: expensiveJob, synapses: toExpensive, cacheable: true },
+    // Обычная job — выполняется всегда
+    normalJob,
+  ],
+};
+```
+
+- `cacheable: true` в `JobInPipeline` — включает кеширование для job
+- Кеш **глобальный по `jobName`** — разделяется между всеми pipeline, использующими эту job (имя job = реализация)
+- Кеш не зависит от жизненного цикла pipeline — удаление pipeline **не** очищает кеш
+- `restartPipelineFromJob` обходит кеш для перезапускаемой job и обновляет его новым результатом
+- Реализации в storage:
+  - `InMemoryPipelineStorage` — кеш в `Map`
+  - `MongoPipelineStorage` — кеш в отдельной коллекции `job_caches`
+
+**Инвалидация кеша:** если реализация `execute` изменилась, кеш необходимо очистить вручную (удалить коллекцию `job_caches` или вызвать `storage.clear()` для in-memory).
 
 ## Stale Jobs Watchdog
 

--- a/packages/neuroline/src/__tests__/in-memory-storage.test.ts
+++ b/packages/neuroline/src/__tests__/in-memory-storage.test.ts
@@ -45,6 +45,20 @@ describe('InMemoryPipelineStorage', () => {
 		expect(updated?.jobs[0].errors?.at(-1)?.message).toContain('timed out');
 	});
 
+	it('сохраняет inputHash при updateJobInput', async () => {
+		const storage = new InMemoryPipelineStorage();
+
+		await storage.create(createState({
+			pipelineId: 'hash-test',
+			jobs: [{ name: 'job-1', status: 'pending', errors: [] }],
+		}));
+
+		await storage.updateJobInput('hash-test', 0, { data: 'test' }, undefined, 'abc123');
+
+		const pipeline = await storage.findById('hash-test');
+		expect(pipeline?.jobs[0].inputHash).toBe('abc123');
+	});
+
 	it('поддерживает пагинацию и фильтрацию по типу', async () => {
 		const storage = new InMemoryPipelineStorage();
 
@@ -60,5 +74,22 @@ describe('InMemoryPipelineStorage', () => {
 		const filtered = await storage.findAll({ pipelineType: 'type-a' });
 		expect(filtered.total).toBe(2);
 		expect(filtered.items.every((item) => item.pipelineType === 'type-a')).toBe(true);
+	});
+});
+
+describe('InMemoryPipelineStorage — job cache', () => {
+	it('сохраняет и находит кешированный артефакт', async () => {
+		const storage = new InMemoryPipelineStorage();
+
+		expect(await storage.findCachedArtifact('job', 'hash1')).toBeNull();
+
+		await storage.saveCachedArtifact('job', 'hash1', { result: 42 });
+
+		const found = await storage.findCachedArtifact('job', 'hash1');
+		expect(found).not.toBeNull();
+		expect(found?.artifact).toEqual({ result: 42 });
+
+		expect(await storage.findCachedArtifact('job', 'hash2')).toBeNull();
+		expect(await storage.findCachedArtifact('other-job', 'hash1')).toBeNull();
 	});
 });

--- a/packages/neuroline/src/__tests__/pipeline-manager.test.ts
+++ b/packages/neuroline/src/__tests__/pipeline-manager.test.ts
@@ -219,6 +219,58 @@ describe('PipelineManager', () => {
 		expect(pipeline2?.jobs[0].artifact).toBe(50);
 	});
 
+	it('downstream job получает артефакт cacheable job из кеша через synapses', async () => {
+		const storage = new InMemoryPipelineStorage();
+		const manager = new PipelineManager({ storage });
+
+		let cacheableExecuteCount = 0;
+
+		const cacheableJob: JobDefinition<number, { value: number }> = {
+			name: 'cacheable-job',
+			execute: async (input) => {
+				cacheableExecuteCount++;
+				return { value: input * 10 };
+			},
+		};
+
+		const downstreamJob: JobDefinition<{ upstream: number }, number> = {
+			name: 'downstream-job',
+			execute: async (input) => input.upstream + 1,
+		};
+
+		const config: PipelineConfig<number> = {
+			name: 'cache-synapse-test',
+			stages: [
+				{ job: asStageJob(cacheableJob), cacheable: true },
+				{
+					job: asStageJob(downstreamJob),
+					synapses: (ctx) => ({
+						upstream: ctx.getArtifact<{ value: number }>('cacheable-job')?.value ?? 0,
+					}),
+				},
+			],
+		};
+
+		manager.registerPipeline(config);
+
+		const first = await runPipeline(manager, 'cache-synapse-test', 5);
+		expect(cacheableExecuteCount).toBe(1);
+
+		const pipeline1 = await storage.findById(first.pipelineId);
+		expect(pipeline1?.jobs[0].artifact).toEqual({ value: 50 });
+		expect(pipeline1?.jobs[1].artifact).toBe(51);
+
+		await storage.delete(first.pipelineId);
+
+		const second = await runPipeline(manager, 'cache-synapse-test', 5);
+
+		expect(cacheableExecuteCount).toBe(1);
+
+		const pipeline2 = await storage.findById(second.pipelineId);
+		expect(pipeline2?.jobs[0].artifact).toEqual({ value: 50 });
+		expect(pipeline2?.jobs[1].artifact).toBe(51);
+	});
+
 	it('restart cacheable job перевыполняет и обновляет кеш', async () => {
 		const storage = new InMemoryPipelineStorage();
 		const manager = new PipelineManager({ storage });

--- a/packages/neuroline/src/__tests__/pipeline-manager.test.ts
+++ b/packages/neuroline/src/__tests__/pipeline-manager.test.ts
@@ -177,6 +177,94 @@ describe('PipelineManager', () => {
 		expect(status.error?.jobName).toBe('fail-job');
 	});
 
+	it('дедуплицирует cacheable job через встроенный кеш storage', async () => {
+		const storage = new InMemoryPipelineStorage();
+		const manager = new PipelineManager({ storage });
+
+		let executeCount = 0;
+
+		const cacheableJob: JobDefinition<number, number> = {
+			name: 'cacheable-job',
+			execute: async (input) => {
+				executeCount++;
+				return input * 10;
+			},
+		};
+
+		const config: PipelineConfig<number> = {
+			name: 'cache-test',
+			stages: [
+				{ job: asStageJob(cacheableJob), cacheable: true },
+			],
+		};
+
+		manager.registerPipeline(config);
+
+		const first = await runPipeline(manager, 'cache-test', 5);
+		expect(executeCount).toBe(1);
+
+		const pipeline1 = await storage.findById(first.pipelineId);
+		expect(pipeline1?.jobs[0].artifact).toBe(50);
+		expect(pipeline1?.jobs[0].inputHash).toBeDefined();
+
+		// Удаляем pipeline и запускаем заново с тем же input
+		await storage.delete(first.pipelineId);
+
+		const second = await runPipeline(manager, 'cache-test', 5);
+
+		// Job не должна выполняться повторно — результат из кеша
+		expect(executeCount).toBe(1);
+
+		const pipeline2 = await storage.findById(second.pipelineId);
+		expect(pipeline2?.jobs[0].artifact).toBe(50);
+	});
+
+	it('restart cacheable job перевыполняет и обновляет кеш', async () => {
+		const storage = new InMemoryPipelineStorage();
+		const manager = new PipelineManager({ storage });
+
+		let executeCount = 0;
+
+		const cacheableJob: JobDefinition<number, number> = {
+			name: 'cacheable-job',
+			execute: async (input) => {
+				executeCount++;
+				return input * 10 + executeCount;
+			},
+		};
+
+		const config: PipelineConfig<number> = {
+			name: 'restart-cache-test',
+			stages: [
+				{ job: asStageJob(cacheableJob), cacheable: true },
+			],
+		};
+
+		manager.registerPipeline(config);
+
+		const first = await runPipeline(manager, 'restart-cache-test', 5);
+		expect(executeCount).toBe(1);
+
+		const pipeline1 = await storage.findById(first.pipelineId);
+		expect(pipeline1?.jobs[0].artifact).toBe(51);
+
+		// Restart — cacheable job должна перевыполниться, несмотря на наличие кеша
+		let restartPromise: Promise<void> | null = null;
+		await manager.restartPipelineFromJob(first.pipelineId, 'cacheable-job', {
+			onExecutionStart: (p) => { restartPromise = p; },
+		});
+		await restartPromise;
+
+		expect(executeCount).toBe(2);
+
+		const pipeline2 = await storage.findById(first.pipelineId);
+		expect(pipeline2?.jobs[0].artifact).toBe(52);
+
+		// Кеш должен быть обновлён новым артефактом
+		const cached = await storage.findCachedArtifact('cacheable-job', pipeline2!.jobs[0].inputHash!);
+		expect(cached?.artifact).toBe(52);
+	});
+
 	describe('manual jobs', () => {
 		it('manual job получает статус awaiting_manual при создании pipeline', async () => {
 			const storage = new InMemoryPipelineStorage();

--- a/packages/neuroline/src/manager.ts
+++ b/packages/neuroline/src/manager.ts
@@ -102,6 +102,14 @@ const computeDefaultHash = (input: unknown): string => {
 };
 
 /**
+ * Вычисляет хеш входных данных job для кеширования
+ */
+const computeJobHash = (jobName: string, input: unknown, options: unknown): string => {
+    const json = JSON.stringify({ jobName, input, options });
+    return crypto.createHash('sha256').update(json).digest('hex').slice(0, 16);
+};
+
+/**
  * Вычисляет хеш структуры pipeline (имена jobs в порядке выполнения)
  * Используется для инвалидации при изменении конфигурации
  */
@@ -122,6 +130,8 @@ interface PipelineExecutionContext {
     readonly mapperContext: SynapseContext;
     readonly jobOptions: Record<string, unknown>;
     defaultInput: unknown;
+    /** Индекс job, для которой нужно пропустить кеш (при restart конкретной job) */
+    readonly forceExecuteJobIndex?: number;
 }
 
 // ============================================================================
@@ -321,11 +331,12 @@ export class PipelineManager {
         pipelineId: string,
         pipelineType: string,
         startFromStageIndex = 0,
+        forceExecuteJobIndex?: number,
     ): Promise<void> {
         this.activePipelines.add(pipelineId);
 
         try {
-            await this.executePipelineInner(pipelineId, pipelineType, startFromStageIndex);
+            await this.executePipelineInner(pipelineId, pipelineType, startFromStageIndex, forceExecuteJobIndex);
         } finally {
             this.activePipelines.delete(pipelineId);
             this.manualJobResolvers.delete(pipelineId);
@@ -336,6 +347,7 @@ export class PipelineManager {
         pipelineId: string,
         pipelineType: string,
         startFromStageIndex: number,
+        forceExecuteJobIndex?: number,
     ): Promise<void> {
         const config = this.getPipelineConfig(pipelineType);
         const pipeline = await this.storage.findById(pipelineId);
@@ -357,6 +369,7 @@ export class PipelineManager {
             },
             jobOptions: pipeline.jobOptions ?? {},
             defaultInput: pipelineInput,
+            forceExecuteJobIndex,
         };
 
         let flatJobIndex = 0;
@@ -577,12 +590,28 @@ export class PipelineManager {
         | { success: true; jobDef: JobInPipeline['job']; artifact: unknown; jobIndex: number }
         | { success: false; jobDef: JobInPipeline['job']; error: string; jobIndex: number }
     > {
-        const { job: jobDef, synapses, retries = 0, retryDelay = 1000 } = jobInPipeline;
+        const { job: jobDef, synapses, retries = 0, retryDelay = 1000, cacheable } = jobInPipeline;
 
         const jobInput = synapses ? synapses(ctx.mapperContext) : ctx.defaultInput;
         const options = ctx.jobOptions[jobDef.name];
 
-        await this.storage.updateJobInput(pipelineId, jobIndex, jobInput, options);
+        const inputHash = cacheable ? computeJobHash(jobDef.name, jobInput, options) : undefined;
+
+        await this.storage.updateJobInput(pipelineId, jobIndex, jobInput, options, inputHash);
+
+        // Проверяем кеш для cacheable jobs (пропускаем при force-перезапуске конкретной job)
+        if (cacheable && inputHash && jobIndex !== ctx.forceExecuteJobIndex) {
+            const cached = await this.storage.findCachedArtifact(jobDef.name, inputHash);
+            if (cached) {
+                this.logger.info('Job cache hit, restoring artifact', {
+                    pipelineId,
+                    jobName: jobDef.name,
+                    inputHash,
+                });
+                await this.storage.updateJobArtifact(pipelineId, jobIndex, cached.artifact, new Date());
+                return { success: true as const, jobDef, artifact: cached.artifact, jobIndex };
+            }
+        }
 
         if (retries > 0) {
             await this.storage.updateJobRetryCount(pipelineId, jobIndex, 0, retries);
@@ -617,6 +646,11 @@ export class PipelineManager {
             try {
                 const artifact = await jobDef.execute(jobInput, options, context);
                 await this.storage.updateJobArtifact(pipelineId, jobIndex, artifact, new Date());
+
+                if (cacheable && inputHash) {
+                    await this.storage.saveCachedArtifact(jobDef.name, inputHash, artifact);
+                }
+
                 return { success: true as const, jobDef, artifact, jobIndex };
             } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : 'Неизвестная ошибка';
@@ -927,6 +961,7 @@ export class PipelineManager {
             pipelineId,
             pipeline.pipelineType,
             stageIndex,
+            jobIndex,
         ).catch((error) => {
             this.logger.error('Pipeline restart execution failed', { pipelineId, error });
         });

--- a/packages/neuroline/src/mongo-storage.ts
+++ b/packages/neuroline/src/mongo-storage.ts
@@ -1,7 +1,8 @@
-import type { Model, Document } from 'mongoose';
+import type { Model, Document, Connection } from 'mongoose';
 
 import type { PipelineStorage, PaginationParams, PaginatedResult } from './storage';
 import type { PipelineState, JobStatus, PipelineStatus, JobError } from './types';
+import { JobCacheSchema } from './mongoose-schema';
 
 /**
  * Интерфейс состояния job в MongoDB документе
@@ -14,6 +15,8 @@ export interface MongoPipelineJobState {
     /** Опции job */
     options?: unknown;
     artifact?: unknown;
+    /** Хеш входных данных для кеширования */
+    inputHash?: string;
     /** История ошибок (включая промежуточные при ретраях) */
     errors?: Array<{ message: string; stack?: string; attempt?: number; logs?: string[]; data?: unknown }>;
     startedAt?: Date;
@@ -39,6 +42,16 @@ export interface MongoPipelineDocument extends Document {
     configHash?: string;
     createdAt?: Date;
     updatedAt?: Date;
+}
+
+/**
+ * Интерфейс документа кеша артефактов в MongoDB
+ */
+export interface MongoJobCacheDocument extends Document {
+    jobName: string;
+    inputHash: string;
+    artifact?: unknown;
+    createdAt?: Date;
 }
 
 /**
@@ -90,7 +103,13 @@ export const sanitizeForMongo = (value: unknown): unknown => {
  * ```
  */
 export class MongoPipelineStorage implements PipelineStorage {
-    constructor(private readonly pipelineModel: Model<MongoPipelineDocument>) { }
+    private readonly cacheModel: Model<MongoJobCacheDocument>;
+
+    constructor(private readonly pipelineModel: Model<MongoPipelineDocument>) {
+        const conn: Connection = pipelineModel.db;
+        this.cacheModel = (conn.models.JobCache as Model<MongoJobCacheDocument>) ??
+            conn.model<MongoJobCacheDocument>('JobCache', JobCacheSchema);
+    }
 
     async findById(pipelineId: string): Promise<PipelineState | null> {
         const doc = await this.pipelineModel.findOne({ pipelineId }).lean().exec();
@@ -103,12 +122,13 @@ export class MongoPipelineStorage implements PipelineStorage {
             currentJobIndex: doc.currentJobIndex,
             input: doc.input,
             jobOptions: doc.jobOptions as Record<string, unknown> | undefined,
-            jobs: doc.jobs.map((j) => ({
+            jobs: (doc.jobs ?? []).map((j) => ({
                 name: j.name,
                 status: j.status,
                 input: j.input,
                 options: j.options,
                 artifact: j.artifact,
+                inputHash: j.inputHash,
                 errors: j.errors ?? [],
                 startedAt: j.startedAt,
                 finishedAt: j.finishedAt,
@@ -149,12 +169,13 @@ export class MongoPipelineStorage implements PipelineStorage {
             currentJobIndex: doc.currentJobIndex,
             input: doc.input,
             jobOptions: doc.jobOptions as Record<string, unknown> | undefined,
-            jobs: doc.jobs.map((j) => ({
+            jobs: (doc.jobs ?? []).map((j) => ({
                 name: j.name,
                 status: j.status,
                 input: j.input,
                 options: j.options,
                 artifact: j.artifact,
+                inputHash: j.inputHash,
                 errors: j.errors ?? [],
                 startedAt: j.startedAt,
                 finishedAt: j.finishedAt,
@@ -293,6 +314,7 @@ export class MongoPipelineStorage implements PipelineStorage {
         jobIndex: number,
         input: unknown,
         options?: unknown,
+        inputHash?: string,
     ): Promise<void> {
         const update: Record<string, unknown> = {
             [`jobs.${jobIndex}.input`]: sanitizeForMongo(input),
@@ -300,6 +322,10 @@ export class MongoPipelineStorage implements PipelineStorage {
 
         if (options !== undefined) {
             update[`jobs.${jobIndex}.options`] = sanitizeForMongo(options);
+        }
+
+        if (inputHash !== undefined) {
+            update[`jobs.${jobIndex}.inputHash`] = inputHash;
         }
 
         await this.pipelineModel.updateOne({ pipelineId }, update).exec();
@@ -407,6 +433,20 @@ export class MongoPipelineStorage implements PipelineStorage {
         }
 
         await this.pipelineModel.updateOne({ pipelineId }, { $set: update }).exec();
+    }
+
+    async findCachedArtifact(jobName: string, inputHash: string): Promise<{ artifact: unknown } | null> {
+        const doc = await this.cacheModel.findOne({ jobName, inputHash }).lean().exec();
+        if (!doc) return null;
+        return { artifact: doc.artifact };
+    }
+
+    async saveCachedArtifact(jobName: string, inputHash: string, artifact: unknown): Promise<void> {
+        await this.cacheModel.updateOne(
+            { jobName, inputHash },
+            { $set: { artifact: sanitizeForMongo(artifact) } },
+            { upsert: true },
+        ).exec();
     }
 }
 

--- a/packages/neuroline/src/mongoose-schema.ts
+++ b/packages/neuroline/src/mongoose-schema.ts
@@ -37,6 +37,8 @@ export const PipelineJobStateSchema = new MongooseSchema<MongoPipelineJobState>(
             ],
             default: [],
         },
+        /** Хеш входных данных для кеширования */
+        inputHash: { type: String },
         startedAt: { type: Date },
         finishedAt: { type: Date },
         /** Количество выполненных ретраев */
@@ -132,4 +134,28 @@ PipelineSchema.index(
         name: 'processing_jobs_watchdog',
     },
 );
+
+// ============================================================================
+// Job Cache Schema (отдельная коллекция для кеша артефактов cacheable jobs)
+// ============================================================================
+
+import type { MongoJobCacheDocument } from './mongo-storage';
+
+/**
+ * Mongoose схема кеша артефактов.
+ * Хранится отдельно от pipeline — удаление pipeline не удаляет кеш.
+ * Ключ: { jobName, inputHash }.
+ */
+export const JobCacheSchema = new MongooseSchema<MongoJobCacheDocument>(
+    {
+        jobName: { type: String, required: true },
+        inputHash: { type: String, required: true },
+        artifact: { type: MongooseSchema.Types.Mixed },
+    },
+    {
+        timestamps: { createdAt: true, updatedAt: false },
+    },
+);
+
+JobCacheSchema.index({ jobName: 1, inputHash: 1 }, { unique: true });
 

--- a/packages/neuroline/src/storage.ts
+++ b/packages/neuroline/src/storage.ts
@@ -95,12 +95,14 @@ export interface PipelineStorage {
      * @param jobIndex - индекс job
      * @param input - входные данные job (результат synapses)
      * @param options - опции job
+     * @param inputHash - хеш входных данных для кеширования (опционально)
      */
     updateJobInput(
         pipelineId: string,
         jobIndex: number,
         input: unknown,
         options?: unknown,
+        inputHash?: string,
     ): Promise<void>;
 
     /**
@@ -151,6 +153,18 @@ export interface PipelineStorage {
         /** Новые опции для jobs (полностью заменяют существующие) */
         jobOptions?: Record<string, unknown>;
     }): Promise<void>;
+
+    /**
+     * Найти кешированный артефакт cacheable job по имени и хешу входных данных.
+     * Кеш не привязан к pipelineId — удаление pipeline не удаляет кеш.
+     */
+    findCachedArtifact(jobName: string, inputHash: string): Promise<{ artifact: unknown } | null>;
+
+    /**
+     * Сохранить артефакт cacheable job в кеш.
+     * При совпадении ключа { jobName, inputHash } — перезаписывает.
+     */
+    saveCachedArtifact(jobName: string, inputHash: string, artifact: unknown): Promise<void>;
 }
 
 /**
@@ -158,6 +172,7 @@ export interface PipelineStorage {
  */
 export class InMemoryPipelineStorage implements PipelineStorage {
     private readonly pipelines = new Map<string, PipelineState>();
+    private readonly jobCache = new Map<string, unknown>();
 
     async findById(pipelineId: string): Promise<PipelineState | null> {
         return this.pipelines.get(pipelineId) ?? null;
@@ -288,12 +303,16 @@ export class InMemoryPipelineStorage implements PipelineStorage {
         jobIndex: number,
         input: unknown,
         options?: unknown,
+        inputHash?: string,
     ): Promise<void> {
         const pipeline = this.pipelines.get(pipelineId);
         if (pipeline && pipeline.jobs[jobIndex]) {
             pipeline.jobs[jobIndex].input = input;
             if (options !== undefined) {
                 pipeline.jobs[jobIndex].options = options;
+            }
+            if (inputHash !== undefined) {
+                pipeline.jobs[jobIndex].inputHash = inputHash;
             }
             pipeline.updatedAt = new Date();
         }
@@ -397,9 +416,20 @@ export class InMemoryPipelineStorage implements PipelineStorage {
         pipeline.updatedAt = new Date();
     }
 
+    async findCachedArtifact(jobName: string, inputHash: string): Promise<{ artifact: unknown } | null> {
+        const key = `${jobName}::${inputHash}`;
+        if (!this.jobCache.has(key)) return null;
+        return { artifact: this.jobCache.get(key) };
+    }
+
+    async saveCachedArtifact(jobName: string, inputHash: string, artifact: unknown): Promise<void> {
+        this.jobCache.set(`${jobName}::${inputHash}`, artifact);
+    }
+
     /** Для тестов: очистить все данные */
     clear(): void {
         this.pipelines.clear();
+        this.jobCache.clear();
     }
 
     /** Для тестов: получить все пайплайны */
@@ -407,5 +437,3 @@ export class InMemoryPipelineStorage implements PipelineStorage {
         return Array.from(this.pipelines.values());
     }
 }
-
-

--- a/packages/neuroline/src/types.ts
+++ b/packages/neuroline/src/types.ts
@@ -118,6 +118,11 @@ export interface JobInPipeline<
      * Для запуска используется метод PipelineManager.runManualJob().
      */
     manual?: boolean;
+    /**
+     * Включает кеширование результата job через JobCacheStorage.
+     * При совпадении inputHash результат берётся из кеша без повторного выполнения.
+     */
+    cacheable?: boolean;
 }
 
 /** JobInPipeline с фиксированным типом pipeline input и "любыми" job-типами */
@@ -269,6 +274,8 @@ export interface JobState<TInput = unknown, TOutput = unknown, TOptions = unknow
     options?: TOptions;
     /** Артефакт (результат выполнения) */
     artifact?: TOutput;
+    /** Хеш входных данных job (для кеширования через JobCacheStorage) */
+    inputHash?: string;
     /** История ошибок (пустой массив, если ошибок нет) */
     errors: Array<JobError>;
     /** Время начала выполнения */


### PR DESCRIPTION
- Introduced caching mechanism for jobs marked as cacheable, allowing results to be retrieved from cache based on input hash without re-execution.
- Updated PipelineManager to handle job caching, including methods for saving and retrieving cached artifacts.
- Enhanced MongoDB and in-memory storage implementations to support caching functionality, ensuring artifacts persist independently of pipeline lifecycle.
- Added new PrepareConfig job to demonstrate caching capabilities, improving performance by reducing execution time on repeated runs with the same input.
- Updated tests to validate caching behavior and ensure correct artifact retrieval from cache.